### PR TITLE
Add vVERSION output as convenience

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,15 @@ outputs:
   patch:
     description: 'Next Patch Version'
     required: true
+  v_mayor:
+    description: 'Next Mayor Version (prefixed with v)'
+    required: true
+  v_minor:
+    description: 'Next Minor Version (prefixed with v)'
+    required: true
+  v_patch:
+    description: 'Next Patch Version (prefixed with v)'
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/src/Next.php
+++ b/src/Next.php
@@ -10,9 +10,15 @@ final class Next
     {
         $version = Version::fromString($versionString);
 
+        // Raw versions
         $output  = '::set-output name=mayor::' . $version->incrementMajor() . \PHP_EOL;
         $output .= '::set-output name=minor::' . $version->incrementMinor() . \PHP_EOL;
         $output .= '::set-output name=patch::' . $version->incrementPatch() . \PHP_EOL;
+
+        // v prefixed versions
+        $output .= '::set-output name=v_mayor::v' . $version->incrementMajor() . \PHP_EOL;
+        $output .= '::set-output name=v_minor::v' . $version->incrementMinor() . \PHP_EOL;
+        $output .= '::set-output name=v_patch::v' . $version->incrementPatch() . \PHP_EOL;
 
         return $output;
     }

--- a/tests/NextTest.php
+++ b/tests/NextTest.php
@@ -25,6 +25,20 @@ final class NextTest extends TestCase
             '1.1.0',
             '1.0.1',
         ];
+
+        yield 'v0.1.0' => [
+            'v0.1.0',
+            '1.0.0',
+            '0.2.0',
+            '0.1.1',
+        ];
+
+        yield 'v1.0.0' => [
+            'v1.0.0',
+            '2.0.0',
+            '1.1.0',
+            '1.0.1',
+        ];
     }
 
     /**
@@ -36,10 +50,13 @@ final class NextTest extends TestCase
     {
         $output = Next::run($version);
         $output = \str_replace(\PHP_EOL, '', $output);
-        [$_, $mayor, $minor, $patch] = \explode('::set-output name=', $output);
+        [$_, $mayor, $minor, $patch, $mayorV, $minorV, $patchV] = \explode('::set-output name=', $output);
 
         self::assertSame('mayor::' . $expectedMayor, $mayor, 'mayor');
         self::assertSame('minor::' . $expectedMinor, $minor, 'minor');
         self::assertSame('patch::' . $expectedPatch, $patch, 'patch');
+        self::assertSame('v_mayor::v' . $expectedMayor, $mayorV, 'v_mayor');
+        self::assertSame('v_minor::v' . $expectedMinor, $minorV, 'v_minor');
+        self::assertSame('v_patch::v' . $expectedPatch, $patchV, 'v_patch');
     }
 }


### PR DESCRIPTION
While I personally use `1.2.3` there are enough developers/projects/companies out there using `v1.2.3` to warrant adding support for it.